### PR TITLE
Throw error for 'field not found'

### DIFF
--- a/builder/index.js
+++ b/builder/index.js
@@ -80,6 +80,7 @@ class Collection extends DBType {
     if (this.key.length) {
       for (const component of this.key) {
         const field = this.schema.fieldsByName.get(component)
+        if (!field) throw new Error('Field not found: ' + component)
         const resolvedType = this.builder.schema.resolve(field.type.fqn, { aliases: false })
         this.keyEncoding.push(resolvedType.name)
       }


### PR DESCRIPTION
Context: I was changing a field name in the schema and forgot to change in the builder's key definition, the message was not immediately clear.

`main` branch

```
Uncaught TypeError: Cannot read properties of undefined (reading 'type')
```

this PR

```
Uncaught Error: Field not found: key
```