### PR TITLE
Error message when encoding an invalid value at insert()

### DIFF
--- a/index.js
+++ b/index.js
@@ -472,7 +472,12 @@ class HyperDB {
 
     const snap = this.engineSnapshot
     const key = collection.encodeKey(doc)
-    const value = collection.encodeValue(this.version, doc)
+    let value
+    try {
+      value = collection.encodeValue(this.version, doc)
+    } catch (error) {
+      throw new Error(collectionName + ': failed to encode value for insertion')
+    }
 
     if (snap !== null) snap.ref()
 


### PR DESCRIPTION
I didn't pass a required field at insert, thought the error message would be confusing for someone else playing with hyperdb. Probably there's a better solution like a full schema validation but for now this helps.

```js
db.insert('@pear/bundle', { link: key, encryptionKey }) // missing `appStorage`
```

`main` branch:

```
stack=Error: Cannot read properties of undefined (reading 'byteLength')
    at Helper.pick (pear://dev/test/helper.js:217:68)
    at async testVersions (pear://dev/test/01-smoke.test.js:27:20)
    at async Promise.all (index 0)
    at async pear://dev/test/01-smoke.test.js:87:3
    at async Test._run (pear://dev/node_modules/brittle/index.js:577:7)
    "sidecarStack": "TypeError: Cannot read properties of undefined (reading 'byteLength')\n    at Buffer.byteLength (bare:/bare.js:6031:17)\n    at Object.byteLength (file:///Users/user/holepunch/pear/node_modules/b4a/index.js:22:17)\n    at Object.preencode (file:///Users/user/holepunch/pear/node_modules/compact-encoding/index.js:376:23)\n    at Object.preencode (file:///Users/user/holepunch/pear/spec/db/messages.js:123:14)\n    at Object.preencode (file:///Users/user/holepunch/pear/spec/db/messages.js:204:11)\n    at Object.encode (file:///Users/user/holepunch/pear/node_modules/compact-encoding/index.js:708:7)\n    at Object.encodeValue (file:///Users/user/holepunch/pear/spec/db/index.js:53:14)\n    at HyperDB.insert (file:///Users/user/holepunch/pear/node_modules/hyperdb/index.js:475:30)\n    at Sidecar.permit (file:///Users/user/holepunch/pear/subsystems/sidecar/index.js:431:21)\n    at #op (file:///Users/user/holepunch/pear/subsystems/sidecar/ops/stage.js:56:19)"
```

This PR:

```
stack=Error: @pear/bundle: failed to encode value for insertion
    at Helper.pick (pear://dev/test/helper.js:217:68)
    at async testDhtBootstrap (pear://dev/test/01-smoke.test.js:63:20)
    at async Promise.all (index 1)
    at async pear://dev/test/01-smoke.test.js:87:3
    at async Test._run (pear://dev/node_modules/brittle/index.js:577:7)
    "sidecarStack": "Error: @pear/bundle: failed to encode value for insertion\n    at HyperDB.insert (file:///Users/user/holepunch/pear/node_modules/hyperdb/index.js:479:13)\n    at Sidecar.permit (file:///Users/user/holepunch/pear/subsystems/sidecar/index.js:431:21)\n    at #op (file:///Users/user/holepunch/pear/subsystems/sidecar/ops/stage.js:56:19)"
```