### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is that simple.
 
 ## API
 
-#### `db = Hyperdb.bee(bee, definition, [options])`
+#### `db = Hyperdb.bee(hypercore, definition, [options])`
 
 Make a db backed by Hyperbee. P2P!
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It is that simple.
 
 Make a db backed by Hyperbee. P2P!
 
-#### `db = Hyperdb.rocks(bee, definition, [options])`
+#### `db = Hyperdb.rocks(path, definition, [options])`
 
 Make a db backed by RocksDB. Local only!
 


### PR DESCRIPTION
HyperDB.bee() does not expect another bee as a parameter but a Hypercore, this PR fixes the typo in readme.