### PR TITLE
Adding registerSchema to builder

### DIFF
--- a/builder/codegen.js
+++ b/builder/codegen.js
@@ -72,11 +72,11 @@ module.exports = function generateCode (hyperdb, { directory = '.', esm = false 
   str += '\n'
   if (esm) {
     str += `import { IndexEncoder, c } from '${pkg.name}/runtime'\n`
-    str += 'import { version, getEncoding, setVersion } from \'./messages.js\'\n'
+    str += `import { version, getEncoding, setVersion } from '${hyperdb.schema.dir}'\n`
     str += '\n'
   } else {
     str += `const { IndexEncoder, c } = require('${pkg.name}/runtime')\n`
-    str += 'const { version, getEncoding, setVersion } = require(\'./messages.js\')\n'
+    str += `const { version, getEncoding, setVersion } = require('${hyperdb.schema.dir}')\n`
     str += '\n'
   }
 

--- a/builder/example/example.js
+++ b/builder/example/example.js
@@ -94,11 +94,10 @@ example.register({
   ]
 })
 
-Hyperschema.toDisk(schema)
-
-const db = HyperDB.from(SCHEMA_DIR, DB_DIR)
+const db = HyperDB.from(DB_DIR)
 const exampleDb = db.namespace('example')
 
+exampleDb.registerSchema(schema)
 exampleDb.require('./helpers.js')
 
 exampleDb.collections.register({
@@ -153,4 +152,5 @@ exampleDb.indexes.register({
   key: ['name', 'tags']
 })
 
+Hyperschema.toDisk(schema)
 HyperDB.toDisk(db)

--- a/test/indexes.js
+++ b/test/indexes.js
@@ -191,9 +191,9 @@ function createExampleDB (HyperDB, Hyperschema, paths) {
     ]
   })
 
-  Hyperschema.toDisk(schema)
+  const db = HyperDB.from(paths.db)
+  db.registerSchema(schema)
 
-  const db = HyperDB.from(paths.schema, paths.db)
   const exampleDB = db.namespace('example')
 
   exampleDB.require(paths.helpers)
@@ -239,5 +239,6 @@ function createExampleDB (HyperDB, Hyperschema, paths) {
     }
   })
 
+  Hyperschema.toDisk(schema)
   HyperDB.toDisk(db)
 }

--- a/test/trigger.js
+++ b/test/trigger.js
@@ -65,11 +65,10 @@ function createExampleDB (HyperDB, Hyperschema, paths) {
     ]
   })
 
-  Hyperschema.toDisk(schema)
+  const db = HyperDB.from(paths.db)
+  db.registerSchema(schema)
 
-  const db = HyperDB.from(paths.schema, paths.db)
   const exampleDB = db.namespace('example')
-
   exampleDB.require(paths.helpers)
 
   exampleDB.collections.register({
@@ -85,5 +84,6 @@ function createExampleDB (HyperDB, Hyperschema, paths) {
     trigger: 'triggerCountMembers'
   })
 
+  Hyperschema.toDisk(schema)
   HyperDB.toDisk(db)
 }


### PR DESCRIPTION
Updates the signature of `HyperDB.from(schemaDir, dbDir)` to `HyperDB.from(dbDir)` and adds a `registerSchema` method for registering a hyperschema instance after `from`.

This makes composition easier (hyperdb isn't responsible for persisting the schema anymore), and also lets us deduplicate messages.js files on disk.