### PR TITLE
Refactor `trigger` cb to pass `isDelete` vs duplicate doc on insert

### DIFF
--- a/builder/example/helpers.js
+++ b/builder/example/helpers.js
@@ -2,9 +2,9 @@ exports.mapStruct = (record, context) => [
   { name: record.name, age: record.age }
 ]
 
-exports.triggerCollection = async (db, key, record, context) => {
+exports.triggerCollection = async (db, key, isDelete, context) => {
   const info = (await db.get('@example/collection1-info')) || { count: 0 }
   const existing = await db.get('@example/collection1', key)
-  if (existing && record) return
-  await db.insert('@example/collection1-info', { count: record ? info.count + 1 : info.count - 1 })
+  if (existing && !isDelete) return
+  await db.insert('@example/collection1-info', { count: isDelete ? info.count - 1 : info.count + 1 })
 }

--- a/index.js
+++ b/index.js
@@ -457,8 +457,8 @@ class HyperDB {
   }
 
   // TODO: needs to wait for pending inserts/deletes and then lock all future ones whilst it runs
-  _runTrigger (collection, key, doc) {
-    return collection.trigger(this, key, doc, this.context)
+  _runTrigger (collection, key, isDelete) {
+    return collection.trigger(this, key, isDelete, this.context)
   }
 
   async delete (collectionName, doc) {
@@ -478,7 +478,7 @@ class HyperDB {
 
     try {
       prevValue = await this.engineSnapshot.get(key)
-      if (collection.trigger !== null) await this._runTrigger(collection, doc, null)
+      if (collection.trigger !== null) await this._runTrigger(collection, doc, true)
 
       if (prevValue === null) {
         this.updates.delete(key)
@@ -522,7 +522,7 @@ class HyperDB {
 
     try {
       prevValue = await this.engineSnapshot.get(key)
-      if (collection.trigger !== null) await this._runTrigger(collection, doc, doc)
+      if (collection.trigger !== null) await this._runTrigger(collection, doc, false)
 
       if (prevValue !== null && b4a.equals(value, prevValue)) {
         this.updates.delete(key)

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -8,15 +8,13 @@ exports.mapNameToLowerCase = (record, context) => {
   return name ? [name] : []
 }
 
-exports.triggerCountMembers = async (db, key, record) => {
+exports.triggerCountMembers = async (db, key, isDelete, context) => {
   const digest = (await db.get('@example/digest')) || { count: 0 }
 
-  const prev = !!(await db.get('@example/members', key))
-  const next = !!record
+  const existing = await db.get('@example/members', key)
+  if (existing && !isDelete) return
 
-  if (prev === next) return
-
-  digest.count += next ? 1 : -1
+  digest.count += isDelete ? -1 : 1
 
   await db.insert('@example/digest', digest)
 }


### PR DESCRIPTION
Previously the `trigger` callback function signature was:

```js
async function triggerCallback (db, key, record) {}
```

`record` was either:
- a duplicate of `key` for `db.insert()`
- `null` for `db.delete()`

This PR refactors `record` into `isDelete` which is `true` for `db.delete()` and `false` for `db.insert()`. This was motivated by the fact that `record` didn't give addition information about the document that triggered the callback.