### PR TITLE
Add failing snapshot close test

### DIFF
--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -92,3 +92,15 @@ test('a divergent tx should not clear the memview', async function ({ create }, 
 
   await db.close()
 })
+
+test('root close waits for snapshot closes', async function ({ create }, t) {
+  const db = await create()
+
+  const snap = db.snapshot()
+  const snapOfSnap = snap.snapshot()
+
+  await db.close()
+
+  t.ok(snap.closed)
+  t.ok(snapOfSnap.closed)
+})


### PR DESCRIPTION
Closing the root database should wait for all snapshots to close