### PR TITLE
Dynamically set the definition with setDefinition

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,6 +296,11 @@ class HyperDB {
     return this.rootInstance !== null && this.rootInstance !== this
   }
 
+  setDefinition (definition) {
+    this.version = definition.version
+    this.definition = definition
+  }
+
   cork () {
     if (this.engineSnapshot !== null) this.engineSnapshot.cork()
   }


### PR DESCRIPTION
Very useful inside of the Autobase apply code, where we need to dynamically load/set definitions but are only instantiating the HyperDB inside of the `open` hook once.