### PR TITLE
Don't pass down to bee2 more opts than are needed

### DIFF
--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -48,11 +48,12 @@ function createTester(type) {
       : type === 'bee'
         ? (dir, def, opts = {}) => HyperDB.bee(new Hypercore(dir, opts.key), def, opts)
         : (dir, def, opts = {}) => {
-            return HyperDB.bee2(
-              new Hyperbee2(new Corestore(dir), { ...opts, autoUpdate: true }),
-              def,
-              opts
-            )
+            const beeOpts = {
+              autoUpdate: true,
+              key: opts.key
+            }
+
+            return HyperDB.bee2(new Hyperbee2(new Corestore(dir), beeOpts), def, opts)
           }
 
   const test = runner(brittle)


### PR DESCRIPTION
`trace` was conflicting with `hyperbee2`. But `key` is the only opts we need to pass down for our tests