### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "b4a": "^1.6.6",
-    "compact-encoding": "^2.15.0",
+    "compact-encoding": "^3.0.0",
     "generate-object-property": "^2.0.0",
     "generate-string": "^1.0.1",
     "hyperbee": "^2.24.2",


### PR DESCRIPTION
Depends on:

- https://github.com/holepunchto/hypercore/pull/800
- https://github.com/holepunchto/hyperschema/pull/56
- rocksdb-native being published